### PR TITLE
Remote address fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -280,7 +280,7 @@ func createUDPConnection(address string, port int, payloadType uint8) (*udpConn,
 	// Create a local addr
 	var laddr *net.UDPAddr
 	var resolveLocalErr error
-	if laddr, resolveLocalErr = net.ResolveUDPAddr("udp", fmt.Sprintf("%s:", address)); resolveLocalErr != nil {
+	if laddr, resolveLocalErr = net.ResolveUDPAddr("udp", fmt.Sprintf("%s:", "0.0.0.0")); resolveLocalErr != nil {
 		return nil, resolveLocalErr
 	}
 

--- a/main.go
+++ b/main.go
@@ -277,13 +277,6 @@ func createUDPConnection(address string, port int, payloadType uint8) (*udpConn,
 
 	var udpConnection udpConn = udpConn{port: port, payloadType: payloadType}
 
-	// Create a local addr
-	var laddr *net.UDPAddr
-	var resolveLocalErr error
-	if laddr, resolveLocalErr = net.ResolveUDPAddr("udp", fmt.Sprintf("%s:", "0.0.0.0")); resolveLocalErr != nil {
-		return nil, resolveLocalErr
-	}
-
 	// Create remote addr
 	var raddr *net.UDPAddr
 	var resolveRemoteErr error
@@ -293,7 +286,7 @@ func createUDPConnection(address string, port int, payloadType uint8) (*udpConn,
 
 	// Dial udp
 	var udpConnErr error
-	if udpConnection.conn, udpConnErr = net.DialUDP("udp", laddr, raddr); udpConnErr != nil {
+	if udpConnection.conn, udpConnErr = net.DialUDP("udp", nil, raddr); udpConnErr != nil {
 		return nil, udpConnErr
 	}
 	return &udpConnection, nil


### PR DESCRIPTION
If `address` belongs to a remote host, and is associated with `laddr`, DialUDP will fail due to it not being able to bind to a remote address. If `nil` is passed in `laddr`'s place, a valid local address will be automatically chosen per the documenation for `net.DialUDP` linked [here](https://golang.org/pkg/net/#DialUDP).  